### PR TITLE
point to ros1 archive branches

### DIFF
--- a/install/https.rosinstall
+++ b/install/https.rosinstall
@@ -4,38 +4,39 @@
 - git:
     local-name: kimera_pgmo
     uri: https://github.com/MIT-SPARK/Kimera-PGMO.git
-    version: main
+    version: archive/ros_noetic
 - git:
     local-name: kimera_rpgo
     uri: https://github.com/MIT-SPARK/Kimera-RPGO.git
-    version: master
+    version: d28b4df0570d642a2bb00e511344ce1110f87519
 - git:
     local-name: spark_dsg
     uri: https://github.com/MIT-SPARK/Spark-DSG.git
-    version: main
+    version: archive/ros_noetic
 - git:
     local-name: hydra
     uri: https://github.com/MIT-SPARK/Hydra.git
-    version: main
+    version: archive/ros_noetic
 - git:
     local-name: hydra_ros
     uri: https://github.com/MIT-SPARK/Hydra-ROS.git
-    version: main
+    version: archive/ros_noetic
 - git:
     local-name: pose_graph_tools
     uri: https://github.com/MIT-SPARK/pose_graph_tools.git
-    version: master
+    version: archive/ros_noetic
 - git:
     local-name: teaser_plusplus
     uri: https://github.com/MIT-SPARK/TEASER-plusplus.git
+    version: f91cfdb7baed951a3607257bd31f3f6694773497
 - git:
     local-name: spatial_hash
     uri: https://github.com/MIT-SPARK/Spatial-Hash.git
-    version: main
+    version: 88b235966c998ec97cd910dece1c70139235fec1
 - git:
     local-name: config_utilities
     uri: https://github.com/MIT-SPARK/config_utilities.git
-    version: main
+    version: archive/ros_noetic
 
 # Additional Kimera-VIO dependencies:
 - git:
@@ -67,4 +68,4 @@
 - git:
     local-name: semantic_inference
     uri: https://github.com/MIT-SPARK/semantic_inference.git
-    version: main
+    version: archive/ros_noetic

--- a/install/ssh.rosinstall
+++ b/install/ssh.rosinstall
@@ -4,38 +4,39 @@
 - git:
     local-name: kimera_pgmo
     uri: git@github.com:MIT-SPARK/Kimera-PGMO.git
-    version: main
+    version: archive/ros_noetic
 - git:
     local-name: kimera_rpgo
     uri: git@github.com:MIT-SPARK/Kimera-RPGO.git
-    version: master
+    version: d28b4df0570d642a2bb00e511344ce1110f87519
 - git:
     local-name: spark_dsg
     uri: git@github.com:MIT-SPARK/Spark-DSG.git
-    version: main
+    version: archive/ros_noetic
 - git:
     local-name: hydra
     uri: git@github.com:MIT-SPARK/Hydra.git
-    version: main
+    version: archive/ros_noetic
 - git:
     local-name: hydra_ros
     uri: git@github.com:MIT-SPARK/Hydra-ROS.git
-    version: main
+    version: archive/ros_noetic
 - git:
     local-name: pose_graph_tools
     uri: git@github.com:MIT-SPARK/pose_graph_tools.git
-    version: master
+    version: archive/ros_noetic
 - git:
     local-name: teaser_plusplus
     uri: git@github.com:MIT-SPARK/TEASER-plusplus.git
+    version: f91cfdb7baed951a3607257bd31f3f6694773497
 - git:
     local-name: spatial_hash
     uri: git@github.com:MIT-SPARK/Spatial-Hash.git
-    version: main
+    version: 88b235966c998ec97cd910dece1c70139235fec1
 - git:
     local-name: config_utilities
     uri: git@github.com:MIT-SPARK/config_utilities.git
-    version: main
+    version: archive/ros_noetic
 
 # Additional Kimera-VIO dependencies:
 - git:
@@ -67,4 +68,4 @@
 - git:
     local-name: semantic_inference
     uri: git@github.com:MIT-SPARK/semantic_inference.git
-    version: main
+    version: archive/ros_noetic


### PR DESCRIPTION
Updates both rosinstall files to point to the final Hydra ROS1 version. All the new branches/commit hashes are the same as what `main` or `master` points to currently. Can confirm this checkouts the same workspace with both rosinstall files and builds.