### PR TITLE
Fix/external objects

### DIFF
--- a/khronos/CMakeLists.txt
+++ b/khronos/CMakeLists.txt
@@ -80,6 +80,12 @@ ${PROJECT_NAME}
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_library(khronos::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+include(CTest)
+if(BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(tests)
+endif()
+
 ##########
 # Export #
 ##########

--- a/khronos/include/khronos/active_window/active_window.h
+++ b/khronos/include/khronos/active_window/active_window.h
@@ -108,7 +108,7 @@ class ActiveWindow : public hydra::ActiveWindowModule {
     std::vector<KhronosSink::Factory> khronos_sinks;
 
     //! Minimum confidence before object is forwarded to graph builder
-    float min_object_confidence = 0.5f;  
+    float min_object_confidence = 0.5f;
 
     // override layer defaults of Hydra
     Config() : hydra::ActiveWindowModule::Config(false, true) {}
@@ -177,7 +177,10 @@ class ActiveWindow : public hydra::ActiveWindowModule {
   hydra::ActiveWindowOutput::Ptr extractOutputData(const FrameData& data, bool threaded);
 
   /**
-   * @brief Update the tracking status of all blocks and tracks based on the given data. This will update the active/inactive status of blocks and tracks, but will not reset any voxels or tracks. This should be called after meshing and before extracting output data to ensure that the correct objects are extracted and the correct blocks are archived. 
+   * @brief Update the tracking status of all blocks and tracks based on the given data. This will
+   * update the active/inactive status of blocks and tracks, but will not reset any voxels or
+   * tracks. This should be called after meshing and before extracting output data to ensure that
+   * the correct objects are extracted and the correct blocks are archived.
    */
   void updateTrackingStatus(const FrameData& data);
 

--- a/khronos/include/khronos/active_window/data/frame_data_buffer.h
+++ b/khronos/include/khronos/active_window/data/frame_data_buffer.h
@@ -38,7 +38,6 @@
 #pragma once
 
 #include <deque>
-#include <vector>
 
 #include "khronos/active_window/data/frame_data.h"
 #include "khronos/active_window/data/track.h"

--- a/khronos/include/khronos/active_window/data/measurement_clusters.h
+++ b/khronos/include/khronos/active_window/data/measurement_clusters.h
@@ -49,7 +49,7 @@ struct SemanticClusterInfo {
   //! Semantic category ID of this cluster.
   int category_id = -1;
   //! Feature vector (used for open-set)
-  FeatureVector feature = FeatureVector::Zero(1, 1);
+  FeatureVector feature = FeatureVector(0, 0);
 
   explicit SemanticClusterInfo(int category_id) : category_id(category_id) {}
   explicit SemanticClusterInfo(const FeatureVector& feature) : feature(feature) {}
@@ -57,27 +57,20 @@ struct SemanticClusterInfo {
       : category_id(category_id), feature(feature) {}
 };
 
-/**
- * @brief Common data structurefor all detected measurement clusters.
- */
+//! Common data structurefor all detected measurement clusters.
 struct MeasurementCluster {
-  // All pixels associated with this cluster in the object_image.
+  //! All pixels associated with this cluster in the object_image.
   Pixels pixels;
-
-  // 3D axis aligned bounding box of this cluster in world frame.
+  //! 3D axis aligned bounding box of this cluster in world frame.
   BoundingBox bounding_box;
-
-  // Center points of all voxels associated with this cluster in world frame.
+  //! Center points of all voxels associated with this cluster in world frame.
   GlobalIndexSet voxels;
-
-  // ID of this cluster (=value of pixels in the corresponding image).
+  //! ID of this cluster (=value of pixels in the corresponding image).
   int id;
-
   //! Semantic information associated with the cluster
   std::optional<SemanticClusterInfo> semantics;
-
-  // NOTE(nathan) someone might want to consider a dynamic info struct here
 };
+
 using MeasurementClusters = std::vector<MeasurementCluster>;
 
 }  // namespace khronos

--- a/khronos/include/khronos/active_window/data/measurement_clusters.h
+++ b/khronos/include/khronos/active_window/data/measurement_clusters.h
@@ -55,6 +55,10 @@ struct SemanticClusterInfo {
   explicit SemanticClusterInfo(const FeatureVector& feature) : feature(feature) {}
   explicit SemanticClusterInfo(int category_id, const FeatureVector& feature)
       : category_id(category_id), feature(feature) {}
+
+  bool operator==(const SemanticClusterInfo& other) const {
+    return category_id == other.category_id && feature == other.feature;
+  }
 };
 
 //! Common data structurefor all detected measurement clusters.

--- a/khronos/include/khronos/active_window/data/track.h
+++ b/khronos/include/khronos/active_window/data/track.h
@@ -37,7 +37,6 @@
 
 #pragma once
 
-#include <map>
 #include <vector>
 
 #include "khronos/active_window/data/measurement_clusters.h"
@@ -66,6 +65,7 @@ struct Observation {
   // ID of the corresponding DynamicCluster, -1 indicates none.
   int dynamic_cluster_id = -1;
 };
+
 using Observations = std::vector<Observation>;
 
 /**
@@ -109,6 +109,7 @@ struct Track {
 
   void updateSemantics(const std::optional<SemanticClusterInfo>& other_semantics);
 };
+
 using Tracks = std::vector<Track>;
 
 }  // namespace khronos

--- a/khronos/include/khronos/active_window/object_detection/instance_forwarding.h
+++ b/khronos/include/khronos/active_window/object_detection/instance_forwarding.h
@@ -38,7 +38,6 @@
 #pragma once
 
 #include <memory>
-#include <string>
 
 #include <config_utilities/config_utilities.h>
 #include <config_utilities/virtual_config.h>
@@ -60,6 +59,23 @@ class InstanceFilter {
   virtual bool valid(const FrameData& data, int32_t id, const Pixels& pixels) const = 0;
 };
 
+class CategoryFilter : public InstanceFilter {
+ public:
+  struct Config {
+    Config();
+    //! Invalid labels
+    std::vector<int32_t> invalid;
+  } const config;
+
+  explicit CategoryFilter(const Config& config);
+  bool valid(const FrameData& data, int32_t id, const Pixels& pixels) const override;
+
+ private:
+  const std::unordered_set<int32_t> invalid_;
+};
+
+void declare_config(CategoryFilter::Config& config);
+
 class OpenVocabBackgroundFilter : public InstanceFilter {
  public:
   struct Config {
@@ -80,23 +96,6 @@ class OpenVocabBackgroundFilter : public InstanceFilter {
 };
 
 void declare_config(OpenVocabBackgroundFilter::Config& config);
-
-class CategoryFilter : public InstanceFilter {
- public:
-  struct Config {
-    Config();
-    //! Invalid labels
-    std::vector<int32_t> invalid;
-  } const config;
-
-  explicit CategoryFilter(const Config& config);
-  bool valid(const FrameData& data, int32_t id, const Pixels& pixels) const override;
-
- private:
-  const std::unordered_set<int32_t> invalid_;
-};
-
-void declare_config(CategoryFilter::Config& config);
 
 /**
  * @brief Proxy object detector that forwards already detected object instances.

--- a/khronos/include/khronos/active_window/object_detection/instance_forwarding.h
+++ b/khronos/include/khronos/active_window/object_detection/instance_forwarding.h
@@ -37,11 +37,8 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
 #include <string>
-#include <utility>
-#include <vector>
 
 #include <config_utilities/config_utilities.h>
 #include <config_utilities/virtual_config.h>
@@ -57,6 +54,50 @@
 
 namespace khronos {
 
+class InstanceFilter {
+ public:
+  virtual ~InstanceFilter() = default;
+  virtual bool valid(const FrameData& data, int32_t id, const Pixels& pixels) const = 0;
+};
+
+class OpenVocabBackgroundFilter : public InstanceFilter {
+ public:
+  struct Config {
+    //! Discard clusters that are overly similar to background
+    double max_background_score = 0.2;
+    //! Background is specified by the following embedding group (prompts)
+    config::VirtualConfig<hydra::EmbeddingGroup> background;
+    //! Metric to use when comparing embeddings
+    config::VirtualConfig<hydra::EmbeddingDistance> metric{hydra::CosineDistance::Config()};
+  } const config;
+
+  explicit OpenVocabBackgroundFilter(const Config& config);
+  bool valid(const FrameData& data, int32_t id, const Pixels& pixels) const override;
+
+ private:
+  hydra::EmbeddingGroup::Ptr background_;
+  std::unique_ptr<hydra::EmbeddingDistance> metric_;
+};
+
+void declare_config(OpenVocabBackgroundFilter::Config& config);
+
+class CategoryFilter : public InstanceFilter {
+ public:
+  struct Config {
+    Config();
+    //! Invalid labels
+    std::vector<int32_t> invalid;
+  } const config;
+
+  explicit CategoryFilter(const Config& config);
+  bool valid(const FrameData& data, int32_t id, const Pixels& pixels) const override;
+
+ private:
+  const std::unordered_set<int32_t> invalid_;
+};
+
+void declare_config(CategoryFilter::Config& config);
+
 /**
  * @brief Proxy object detector that forwards already detected object instances.
  */
@@ -65,30 +106,22 @@ class InstanceForwarding : public ObjectDetector {
   // Config.
   struct Config {
     int verbosity = hydra::GlobalInfo::instance().getConfig().default_verbosity;
-    // Maximum depth values to consider for object extraction in meters. Use 0 for infinity.
+    //! Maximum depth values to consider for object extraction in meters. Use 0 for infinity.
     float max_range = 0.f;
-
-    // Minimum depth values to consider for object extraction in meters. Use 0 to disable.
+    //! Minimum depth values to consider for object extraction in meters. Use 0 to disable.
     float min_range = 0.f;
-
-    // Discard clusters with fewer pixels than this.
+    //! Treat instance IDs of 0 as unlabeled.
+    bool zero_is_unlabeled = true;
+    //! Discard clusters with fewer pixels than this.
     int min_cluster_size = 0;
-
-    // Discard clusters with more pixels than this (<= 0 disables).
+    //! Discard clusters with more pixels than this (<= 0 disables).
     int max_cluster_size = -1;
-
-    // Discard clusters with less volume than this
+    //! Discard clusters with less volume than this.
     double min_object_volume = 0.0;
-
-    // Discard clusters with more volume than this (if enabled)
+    //! Discard clusters with more volume than this (if enabled).
     double max_object_volume = -1.0;
-
-    // Discard clusters that is overly similary to background
-    double max_background_score = 0.2;
-
-    // Background is specified by the following embedding group (prompts)
-    config::VirtualConfig<hydra::EmbeddingGroup> background;
-    config::VirtualConfig<hydra::EmbeddingDistance> metric{hydra::CosineDistance::Config()};
+    //! Discard instances that match the filter.
+    config::VirtualConfig<InstanceFilter> instance_filter;
   } const config;
 
   // Construction.
@@ -113,18 +146,9 @@ class InstanceForwarding : public ObjectDetector {
   void extractSemanticClusters(FrameData& data);
 
  private:
-  inline static const auto registration_ =
-      config::RegistrationWithConfig<ObjectDetector,
-                                     InstanceForwarding,
-                                     InstanceForwarding::Config>("InstanceForwarding");
-
   const bool filter_by_volume_;
-
-  // Filter out background.
-  hydra::EmbeddingGroup::Ptr background_;
-  std::unique_ptr<hydra::EmbeddingDistance> metric_;
-
   TimeStamp processing_stamp_;
+  std::unique_ptr<InstanceFilter> instance_filter_;
 };
 
 void declare_config(InstanceForwarding::Config& config);

--- a/khronos/include/khronos/active_window/object_detection/instance_forwarding.h
+++ b/khronos/include/khronos/active_window/object_detection/instance_forwarding.h
@@ -86,9 +86,6 @@ class InstanceForwarding : public ObjectDetector {
     // Discard clusters that is overly similary to background
     double max_background_score = 0.2;
 
-    // Treat segmentation with instance id
-    bool instance_id = true;
-
     // Background is specified by the following embedding group (prompts)
     config::VirtualConfig<hydra::EmbeddingGroup> background;
     config::VirtualConfig<hydra::EmbeddingDistance> metric{hydra::CosineDistance::Config()};

--- a/khronos/include/khronos/common/pixel.h
+++ b/khronos/include/khronos/common/pixel.h
@@ -56,6 +56,7 @@ struct Pixel {
   Pixel operator+(const Pixel& other) const { return Pixel(u + other.u, v + other.v); }
   Pixel operator-(const Pixel& other) const { return Pixel(u - other.u, v - other.v); }
   bool operator<(const Pixel& other) const { return u < other.u || (u == other.u && v < other.v); }
+  bool operator==(const Pixel& other) const { return u == other.u && v == other.v; }
 
   // Utilities.
   bool isInImage(const cv::Mat& image) const {

--- a/khronos/src/active_window/active_window.cpp
+++ b/khronos/src/active_window/active_window.cpp
@@ -42,27 +42,26 @@
 #include <hydra/input/sensor_utilities.h>
 #include <hydra/reconstruction/integration_masking.h>
 
-#include "khronos/utils/geometry_utils.h"
-#include "khronos/utils/khronos_attribute_utils.h"
-
 namespace khronos {
-
 namespace {
-    std::shared_ptr<KhronosObjectAttributes> createObjectAttributes(const Track& track){
-    auto object = std::make_shared<KhronosObjectAttributes>();
-    if (track.semantics) {
-      object->semantic_label = track.semantics->category_id;
-      object->semantic_feature = track.semantics->feature;
-    }
-    object->first_observed_ns = {track.first_seen};
-    object->last_observed_ns = {track.last_seen};
 
-    object->bounding_box = track.last_bounding_box;
-    object->position = object->bounding_box.world_P_center.cast<double>();
-    
-    return object;
+std::shared_ptr<KhronosObjectAttributes> createObjectAttributes(const Track& track) {
+  auto object = std::make_shared<KhronosObjectAttributes>();
+  if (track.semantics) {
+    object->semantic_label = track.semantics->category_id;
+    object->semantic_feature = track.semantics->feature;
   }
+
+  object->first_observed_ns = {track.first_seen};
+  object->last_observed_ns = {track.last_seen};
+
+  object->bounding_box = track.last_bounding_box;
+  object->position = object->bounding_box.world_P_center.cast<double>();
+
+  return object;
 }
+
+}  // namespace
 
 void declare_config(SensorProcessor::Config& config) {
   using namespace config;
@@ -118,7 +117,7 @@ ActiveWindow::ActiveWindow(const Config& config, const OutputQueue::Ptr& output_
       frame_data_buffer_(config.frame_data_buffer) {
   if (!map_window_) {
     LOG(WARNING) << "[Khronos Active Window] map_window is required. Set active_window.map_window "
-                  "in config (e.g. type: spatial or type: temporal).";
+                    "in config (e.g. type: spatial or type: temporal).";
   }
   if (!map_.config.with_tracking) {
     LOG(WARNING) << "[Khronos Active Window] Tracking layer disabled for volumetric map! Tracking "
@@ -139,9 +138,9 @@ void ActiveWindow::addKhronosSink(const KhronosSink::Ptr& sink) {
 
 void ActiveWindow::updateTrackingStatus(const FrameData& data) {
   for (auto& track : tracks_) {
-    const Eigen::Vector3d track_pos =
-        track.last_bounding_box.world_P_center.cast<double>();
-    track.is_active = map_window_->inBounds(data.input.timestamp_ns, data.input.world_T_body, track.last_seen, track_pos);
+    const Eigen::Vector3d track_pos = track.last_bounding_box.world_P_center.cast<double>();
+    track.is_active = map_window_->inBounds(
+        data.input.timestamp_ns, data.input.world_T_body, track.last_seen, track_pos);
   }
 }
 
@@ -286,17 +285,17 @@ hydra::ActiveWindowOutput::Ptr ActiveWindow::extractOutputData(const FrameData& 
   }
 
   // TODO(nathan) fix the layer update to not use LayerId
-  auto update = std::make_shared<hydra::LayerUpdate>(2);  
+  auto update = std::make_shared<hydra::LayerUpdate>(2);
   output->graph_update[update->layer] = update;
   extraction_worker_.fill(*update);
 
-  for (const auto& track: tracks_){
-    if(track.confidence < config.min_object_confidence){
+  for (const auto& track : tracks_) {
+    if (track.confidence < config.min_object_confidence) {
       continue;
     }
-    
+
     auto output_object = createObjectAttributes(track);
-    update->updates.push_back(hydra::NodeUpdate {output_object, static_cast<size_t>(track.id)});
+    update->updates.push_back(hydra::NodeUpdate{output_object, static_cast<size_t>(track.id)});
   }
 
   return output;

--- a/khronos/src/active_window/data/frame_data_buffer.cpp
+++ b/khronos/src/active_window/data/frame_data_buffer.cpp
@@ -37,9 +37,6 @@
 
 #include "khronos/active_window/data/frame_data_buffer.h"
 
-#include <map>
-#include <vector>
-
 #include <config_utilities/config_utilities.h>
 
 namespace khronos {
@@ -108,17 +105,18 @@ void FrameDataBuffer::storeData(const FrameData::Ptr& data) {
   }
 }
 
-FrameData::Ptr FrameDataBuffer::getData(const TimeStamp time_stamp) const {
-  if (time_stamp < oldest_time_stamp_) {
+FrameData::Ptr FrameDataBuffer::getData(const TimeStamp stamp) const {
+  if (stamp < oldest_time_stamp_) {
     return nullptr;
   }
-  const auto it =
-      std::find_if(buffer_.begin(), buffer_.end(), [time_stamp](const FrameData::Ptr& data) {
-        return data->input.timestamp_ns == time_stamp;
-      });
+
+  const auto it = std::find_if(buffer_.begin(), buffer_.end(), [stamp](const FrameData::Ptr& data) {
+    return data->input.timestamp_ns == stamp;
+  });
   if (it == buffer_.end()) {
     return nullptr;
   }
+
   return *it;
 }
 

--- a/khronos/src/active_window/data/track.cpp
+++ b/khronos/src/active_window/data/track.cpp
@@ -49,8 +49,8 @@ void Track::updateSemantics(const std::optional<SemanticClusterInfo>& other) {
     return;
   }
 
-  const bool other_has_feature = other->feature.size() != 1;
-  const bool has_feature = semantics->feature.size() != 1;
+  const bool other_has_feature = other->feature.size() > 0;
+  const bool has_feature = semantics->feature.size() > 0;
   if (has_feature && !other_has_feature) {
     return;  // prefer to keep feature
   }

--- a/khronos/src/active_window/object_detection/instance_forwarding.cpp
+++ b/khronos/src/active_window/object_detection/instance_forwarding.cpp
@@ -69,7 +69,7 @@ std::optional<SemanticClusterInfo> extractSemantics(const FrameData& data,
   if (!data.input.label_features.empty()) {
     const auto feature = data.input.label_features.find(id);
     if (feature != data.input.label_features.end()) {
-      return SemanticClusterInfo(id, feature->second);
+      return SemanticClusterInfo(feature->second);
     }
 
     return std::nullopt;
@@ -85,6 +85,27 @@ std::optional<SemanticClusterInfo> extractSemantics(const FrameData& data,
 }
 
 }  // namespace
+
+void declare_config(CategoryFilter::Config& config) {
+  using namespace config;
+  name("CategoryFilter::Config");
+  field(config.invalid, "invalid");
+}
+
+CategoryFilter::Config::Config() : invalid(getDefaultInvalidLabels()) {}
+
+CategoryFilter::CategoryFilter(const Config& config)
+    : config(config::checkValid(config)), invalid_(config.invalid.begin(), config.invalid.end()) {}
+
+bool CategoryFilter::valid(const FrameData& data, int32_t, const Pixels& pixels) const {
+  if (pixels.empty() || data.input.label_image.empty()) {
+    return false;
+  }
+
+  const auto [u, v] = pixels.front();
+  const auto label = data.input.label_image.at<InputData::LabelType>(v, u);
+  return !invalid_.count(label);
+}
 
 void declare_config(OpenVocabBackgroundFilter::Config& config) {
   using namespace config;
@@ -112,27 +133,6 @@ bool OpenVocabBackgroundFilter::valid(const FrameData& data, int32_t id, const P
   }
 
   return true;
-}
-
-void declare_config(CategoryFilter::Config& config) {
-  using namespace config;
-  name("CategoryFilter::Config");
-  field(config.invalid, "invalid");
-}
-
-CategoryFilter::Config::Config() : invalid(getDefaultInvalidLabels()) {}
-
-CategoryFilter::CategoryFilter(const Config& config)
-    : config(config::checkValid(config)), invalid_(config.invalid.begin(), config.invalid.end()) {}
-
-bool CategoryFilter::valid(const FrameData& data, int32_t, const Pixels& pixels) const {
-  if (pixels.empty() || data.input.label_image.empty()) {
-    return false;
-  }
-
-  const auto [u, v] = pixels.front();
-  const auto label = data.input.label_image.at<InputData::LabelType>(v, u);
-  return !invalid_.count(label);
 }
 
 void declare_config(InstanceForwarding::Config& config) {

--- a/khronos/src/active_window/object_detection/instance_forwarding.cpp
+++ b/khronos/src/active_window/object_detection/instance_forwarding.cpp
@@ -46,7 +46,7 @@ namespace khronos {
 namespace {
 
 std::optional<SemanticClusterInfo> extractSemantics(const FrameData& data,
-                                                    InputData::LabelType id,
+                                                    InputData::InstanceType id,
                                                     const Pixels& pixels) {
   if (!data.input.label_features.empty()) {
     const auto feature = data.input.label_features.find(id);
@@ -62,7 +62,7 @@ std::optional<SemanticClusterInfo> extractSemantics(const FrameData& data,
   }
 
   const auto [u, v] = pixels.front();
-  int16_t category_id = data.input.label_image.at<int16_t>(v, u);
+  const auto category_id = data.input.label_image.at<InputData::LabelType>(v, u);
   return SemanticClusterInfo(category_id);
 }
 
@@ -111,7 +111,7 @@ void InstanceForwarding::extractSemanticClusters(FrameData& data) {
   std::unordered_map<FrameData::ObjectImageType, Pixels> clusters;
   for (int u = 0; u < data.input.instance_image.cols; u++) {
     for (int v = 0; v < data.input.instance_image.rows; v++) {
-      const auto& id = data.input.instance_image.at<InputData::LabelType>(v, u);
+      const auto id = data.input.instance_image.at<InputData::InstanceType>(v, u);
       if (id == 0) {
         continue;
       }

--- a/khronos/src/active_window/object_detection/instance_forwarding.cpp
+++ b/khronos/src/active_window/object_detection/instance_forwarding.cpp
@@ -45,6 +45,24 @@
 namespace khronos {
 namespace {
 
+static const auto registration =
+    config::RegistrationWithConfig<ObjectDetector, InstanceForwarding, InstanceForwarding::Config>(
+        "InstanceForwarding");
+
+static const auto open_vocab_registration =
+    config::RegistrationWithConfig<InstanceFilter,
+                                   OpenVocabBackgroundFilter,
+                                   OpenVocabBackgroundFilter::Config>("OpenVocabBackgroundFilter");
+
+static const auto category_registration =
+    config::RegistrationWithConfig<InstanceFilter, CategoryFilter, CategoryFilter::Config>(
+        "CategoryFilter");
+
+std::vector<int32_t> getDefaultInvalidLabels() {
+  const auto& invalid = hydra::GlobalInfo::instance().labelspace().invalid_labels;
+  return {invalid.begin(), invalid.end()};
+}
+
 std::optional<SemanticClusterInfo> extractSemantics(const FrameData& data,
                                                     InputData::InstanceType id,
                                                     const Pixels& pixels) {
@@ -68,32 +86,74 @@ std::optional<SemanticClusterInfo> extractSemantics(const FrameData& data,
 
 }  // namespace
 
+void declare_config(OpenVocabBackgroundFilter::Config& config) {
+  using namespace config;
+  name("OpenVocabBackgroundFilter::Config");
+  field(config.max_background_score, "max_background_score");
+  field(config.background, "background");
+  field(config.metric, "metric");
+}
+
+OpenVocabBackgroundFilter::OpenVocabBackgroundFilter(const Config& config)
+    : config(config::checkValid(config)),
+      background_(config.background.create()),
+      metric_(config.metric.create()) {}
+
+bool OpenVocabBackgroundFilter::valid(const FrameData& data, int32_t id, const Pixels&) const {
+  // Filter background based on given prompt
+  const auto feature = data.input.label_features.find(id);
+  if (feature == data.input.label_features.end()) {
+    return false;
+  }
+
+  auto score = background_->getBestScore(*metric_, feature->second);
+  if (score.score > config.max_background_score) {
+    return false;
+  }
+
+  return true;
+}
+
+void declare_config(CategoryFilter::Config& config) {
+  using namespace config;
+  name("CategoryFilter::Config");
+  field(config.invalid, "invalid");
+}
+
+CategoryFilter::Config::Config() : invalid(getDefaultInvalidLabels()) {}
+
+CategoryFilter::CategoryFilter(const Config& config)
+    : config(config::checkValid(config)), invalid_(config.invalid.begin(), config.invalid.end()) {}
+
+bool CategoryFilter::valid(const FrameData& data, int32_t, const Pixels& pixels) const {
+  if (pixels.empty() || data.input.label_image.empty()) {
+    return false;
+  }
+
+  const auto [u, v] = pixels.front();
+  const auto label = data.input.label_image.at<InputData::LabelType>(v, u);
+  return !invalid_.count(label);
+}
+
 void declare_config(InstanceForwarding::Config& config) {
   using namespace config;
   name("InstanceForwarding");
   field(config.verbosity, "verbosity");
   field(config.max_range, "max_range", "m");
   field(config.min_range, "min_range", "m");
+  field(config.zero_is_unlabeled, "zero_is_unlabeled");
   field(config.min_cluster_size, "min_cluster_size");
   field(config.max_cluster_size, "max_cluster_size");
   field(config.min_object_volume, "min_object_volume", "m");
   field(config.max_object_volume, "max_object_volume", "m");
-  field(config.max_background_score, "max_background_score");
-  config.background.setOptional();
-  field(config.background, "background");
-  config.metric.setOptional();
-  field(config.metric, "metric");
+  config.instance_filter.setOptional();
+  field(config.instance_filter, "instance_filter");
 }
 
 InstanceForwarding::InstanceForwarding(const Config& config)
     : config(config::checkValid(config)),
       filter_by_volume_(config.min_object_volume > 0.0 || config.max_object_volume > 0.0),
-      background_(config.background.create()),
-      metric_(config.metric.create()) {
-  if (background_) {
-    CHECK(metric_) << "Specify the metric if background is set.";
-  }
-}
+      instance_filter_(config.instance_filter.create()) {}
 
 void InstanceForwarding::processInput(const VolumetricMap& /* map */, FrameData& data) {
   processing_stamp_ = data.input.timestamp_ns;
@@ -103,44 +163,25 @@ void InstanceForwarding::processInput(const VolumetricMap& /* map */, FrameData&
 }
 
 void InstanceForwarding::extractSemanticClusters(FrameData& data) {
-  // Forward the semantic image from the input.
-  // NOTE(lschmid): This assumes both images have the same type.
-  data.object_image = data.input.instance_image;
-
-  // Extract clusters.
+  // Extract clusters
   std::unordered_map<FrameData::ObjectImageType, Pixels> clusters;
   for (int u = 0; u < data.input.instance_image.cols; u++) {
     for (int v = 0; v < data.input.instance_image.rows; v++) {
       const auto id = data.input.instance_image.at<InputData::InstanceType>(v, u);
-      if (id == 0) {
+      if (config.zero_is_unlabeled && id == 0) {
         continue;
       }
 
-      // Filter background based on given prompt
-      if (background_) {
-        const auto feature = data.input.label_features.find(id);
-        if (feature == data.input.label_features.end()) {
-          continue;
-        }
-
-        auto score = background_->getBestScore(*metric_, feature->second);
-        if (score.score > config.max_background_score) {
-          continue;
-        }
+      const auto range = data.input.range_image.at<InputData::RangeType>(v, u);
+      if (range < config.min_range || (config.max_range > 0.f && range > config.max_range)) {
+        continue;
       }
 
-      if (config.max_range > 0.f || config.min_range > 0.f) {
-        const float range = data.input.range_image.at<InputData::RangeType>(v, u);
-        if (range < config.min_range || (config.max_range > 0.f && range > config.max_range)) {
-          continue;
-        }
-      }
-
-      data.object_image.at<FrameData::ObjectImageType>(v, u) = id;
       clusters[id].emplace_back(u, v);
     }
   }
 
+  // Filter clusters and populate object image
   for (const auto& [id, pixels] : clusters) {
     const auto curr_num_pixels = static_cast<int>(pixels.size());
     if (curr_num_pixels < config.min_cluster_size ||
@@ -155,6 +196,16 @@ void InstanceForwarding::extractSemanticClusters(FrameData& data) {
           (config.max_object_volume > 0.0 && volume > config.max_object_volume)) {
         continue;
       }
+    }
+
+    if (instance_filter_ && !instance_filter_->valid(data, id, pixels)) {
+      continue;
+    }
+
+    // Technically we could fill the object image during extraction and not worry about filtered
+    // instances but this is probably better
+    for (const auto& [u, v] : pixels) {
+      data.object_image.at<FrameData::ObjectImageType>(v, u) = id;
     }
 
     MeasurementCluster cluster;

--- a/khronos/src/active_window/object_detection/instance_forwarding.cpp
+++ b/khronos/src/active_window/object_detection/instance_forwarding.cpp
@@ -43,6 +43,30 @@
 #include "khronos/utils/geometry_utils.h"
 
 namespace khronos {
+namespace {
+
+std::optional<SemanticClusterInfo> extractSemantics(const FrameData& data,
+                                                    InputData::LabelType id,
+                                                    const Pixels& pixels) {
+  if (!data.input.label_features.empty()) {
+    const auto feature = data.input.label_features.find(id);
+    if (feature != data.input.label_features.end()) {
+      return SemanticClusterInfo(id, feature->second);
+    }
+
+    return std::nullopt;
+  }
+
+  if (data.input.label_image.empty()) {
+    return std::nullopt;
+  }
+
+  const auto [u, v] = pixels.front();
+  int16_t category_id = data.input.label_image.at<int16_t>(v, u);
+  return SemanticClusterInfo(category_id);
+}
+
+}  // namespace
 
 void declare_config(InstanceForwarding::Config& config) {
   using namespace config;
@@ -55,7 +79,6 @@ void declare_config(InstanceForwarding::Config& config) {
   field(config.min_object_volume, "min_object_volume", "m");
   field(config.max_object_volume, "max_object_volume", "m");
   field(config.max_background_score, "max_background_score");
-  field(config.instance_id, "instance_id");
   config.background.setOptional();
   field(config.background, "background");
   config.metric.setOptional();
@@ -82,13 +105,13 @@ void InstanceForwarding::processInput(const VolumetricMap& /* map */, FrameData&
 void InstanceForwarding::extractSemanticClusters(FrameData& data) {
   // Forward the semantic image from the input.
   // NOTE(lschmid): This assumes both images have the same type.
-  data.object_image = data.input.label_image;
+  data.object_image = data.input.instance_image;
 
   // Extract clusters.
   std::unordered_map<FrameData::ObjectImageType, Pixels> clusters;
-  for (int u = 0; u < data.input.label_image.cols; u++) {
-    for (int v = 0; v < data.input.label_image.rows; v++) {
-      const auto& id = data.input.label_image.at<InputData::LabelType>(v, u);
+  for (int u = 0; u < data.input.instance_image.cols; u++) {
+    for (int v = 0; v < data.input.instance_image.rows; v++) {
+      const auto& id = data.input.instance_image.at<InputData::LabelType>(v, u);
       if (id == 0) {
         continue;
       }
@@ -99,6 +122,7 @@ void InstanceForwarding::extractSemanticClusters(FrameData& data) {
         if (feature == data.input.label_features.end()) {
           continue;
         }
+
         auto score = background_->getBestScore(*metric_, feature->second);
         if (score.score > config.max_background_score) {
           continue;
@@ -124,12 +148,8 @@ void InstanceForwarding::extractSemanticClusters(FrameData& data) {
       continue;
     }
 
-    MeasurementCluster cluster;
-    cluster.pixels.insert(cluster.pixels.end(), pixels.begin(), pixels.end());
-    cluster.id = id;
-
     if (filter_by_volume_) {
-      const auto bbox = BoundingBox(utils::VertexMapAdaptor(cluster.pixels, data.input.vertex_map));
+      const auto bbox = BoundingBox(utils::VertexMapAdaptor(pixels, data.input.vertex_map));
       const auto volume = bbox.volume();
       if (volume < config.min_object_volume ||
           (config.max_object_volume > 0.0 && volume > config.max_object_volume)) {
@@ -137,22 +157,10 @@ void InstanceForwarding::extractSemanticClusters(FrameData& data) {
       }
     }
 
-    // Closed set version
-    if (data.input.label_features.empty()) {
-      // modify to parse category id and instance id
-      if (config.instance_id) {
-        int16_t category_id = static_cast<int16_t>((id >> 16) & 0xFFFF);
-        cluster.semantics = SemanticClusterInfo(category_id);
-      } else {
-        cluster.semantics = SemanticClusterInfo(id);
-      }
-    }
-    // TODO(Yun) For now all semantic id is the same (so all label checks are invalid)
-    const auto feature = data.input.label_features.find(id);
-    if (feature != data.input.label_features.end()) {
-      cluster.semantics = SemanticClusterInfo(id, feature->second);
-    }
-
+    MeasurementCluster cluster;
+    cluster.id = id;
+    cluster.pixels.insert(cluster.pixels.end(), pixels.begin(), pixels.end());
+    cluster.semantics = extractSemantics(data, id, pixels);
     data.semantic_clusters.emplace_back(std::move(cluster));
   }
 }

--- a/khronos/src/active_window/tracking/max_iou_tracker.cpp
+++ b/khronos/src/active_window/tracking/max_iou_tracker.cpp
@@ -117,7 +117,7 @@ MatchResult semanticsMatch(const std::optional<SemanticClusterInfo>& lhs,
     return {MatchResult::Status::kMismatchedFeatures};
   }
 
-  if (lhs->feature.size() == 1) {
+  if (!lhs->feature.size()) {
     return {MatchResult::Status::kMatch};  // no openset features
   }
 

--- a/khronos/tests/CMakeLists.txt
+++ b/khronos/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(GTest REQUIRED)
+
+include(GoogleTest)
+enable_testing()
+
+add_executable(
+  test_${PROJECT_NAME}
+  main.cpp active_window/object_detection/test_instance_forwarding.cpp)
+target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME} GTest::gtest_main)
+gtest_add_tests(TARGET test_${PROJECT_NAME})

--- a/khronos/tests/active_window/object_detection/test_instance_forwarding.cpp
+++ b/khronos/tests/active_window/object_detection/test_instance_forwarding.cpp
@@ -1,0 +1,43 @@
+/* -----------------------------------------------------------------------------
+ * Copyright 2022 Massachusetts Institute of Technology.
+ * All Rights Reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Research was sponsored by the United States Air Force Research Laboratory and
+ * the United States Air Force Artificial Intelligence Accelerator and was
+ * accomplished under Cooperative Agreement Number FA8750-19-2-1000. The views
+ * and conclusions contained in this document are those of the authors and should
+ * not be interpreted as representing the official policies, either expressed or
+ * implied, of the United States Air Force or the U.S. Government. The U.S.
+ * Government is authorized to reproduce and distribute reprints for Government
+ * purposes notwithstanding any copyright notation herein.
+ * -------------------------------------------------------------------------- */
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <khronos/active_window/object_detection/instance_forwarding.h>
+
+namespace khronos {
+
+TEST(InstanceForwarding, Foo) { SUCCEED(); }
+
+}  // namespace khronos

--- a/khronos/tests/active_window/object_detection/test_instance_forwarding.cpp
+++ b/khronos/tests/active_window/object_detection/test_instance_forwarding.cpp
@@ -34,10 +34,314 @@
  * -------------------------------------------------------------------------- */
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <hydra/common/global_info.h>
 #include <khronos/active_window/object_detection/instance_forwarding.h>
 
 namespace khronos {
+namespace {
 
-TEST(InstanceForwarding, Foo) { SUCCEED(); }
+struct ConfigGuard {
+  ConfigGuard(bool init = true) {
+    if (init) {
+      hydra::PipelineConfig config;
+      hydra::GlobalInfo::init(config);
+    }
+  }
+
+  ~ConfigGuard() { hydra::GlobalInfo::instance().reset(); }
+};
+
+Eigen::VectorXf getOneHot(size_t index, size_t dims = 10) {
+  Eigen::VectorXf vec = Eigen::VectorXf::Zero(dims);
+  vec(index) = 1.0f;
+  return vec;
+}
+
+}  // namespace
+
+void PrintTo(const SemanticClusterInfo& info, std::ostream* os) {
+  const Eigen::IOFormat fmt(
+      Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", "; ", "", "", "[", "]");
+  *os << "(id=" << info.category_id << ", vec" << info.feature.format(fmt) << ")";
+}
+
+TEST(InstanceForwarding, CategoryFilterCorrect) {
+  ConfigGuard guard;
+
+  CategoryFilter::Config config;
+  config.invalid = {1, 2, 3};
+  CategoryFilter filter(config);
+
+  {  // no labels means everything fails
+    hydra::InputData input{nullptr};
+    const FrameData data{input};
+    EXPECT_FALSE(filter.valid(data, 1, {{1, 2}}));
+  }
+
+  {  // no pixels means cluster fails
+    InputData input{nullptr};
+    input.label_image = cv::Mat(3, 2, CV_32SC1);
+    input.label_image.at<InputData::LabelType>(2, 1) = 2;
+
+    const FrameData data{input};
+    EXPECT_FALSE(filter.valid(data, 1, {}));
+  }
+
+  {  // invalid label means instance fails
+    InputData input{nullptr};
+    input.label_image = cv::Mat(3, 2, CV_32SC1);
+    input.label_image.at<InputData::LabelType>(2, 1) = 2;
+
+    const FrameData data{input};
+    EXPECT_FALSE(filter.valid(data, 1, {{1, 2}}));
+  }
+
+  {  // valid label means instance passes
+    InputData input{nullptr};
+    input.label_image = cv::Mat(3, 2, CV_32SC1);
+    input.label_image.at<InputData::LabelType>(2, 1) = 4;
+
+    const FrameData data{input};
+    EXPECT_TRUE(filter.valid(data, 1, {{1, 2}}));
+  }
+}
+
+TEST(InstanceForwarding, OpenVocabFilterCorrect) {
+  ConfigGuard guard;
+
+  hydra::EmbeddingGroup group;
+  group.embeddings = {getOneHot(0), getOneHot(1), getOneHot(2)};
+  OpenVocabBackgroundFilter::Config config;
+  config.background = group;
+  OpenVocabBackgroundFilter filter(config);
+
+  {  // no feature means everything fails
+    hydra::InputData input{nullptr};
+    input.label_features = {{1, getOneHot(1)}};
+    const FrameData data{input};
+    EXPECT_FALSE(filter.valid(data, 2, {{1, 2}}));
+  }
+
+  {  // feature match means ID fails
+    hydra::InputData input{nullptr};
+    input.label_features = {{1, getOneHot(1)}};
+    const FrameData data{input};
+    EXPECT_FALSE(filter.valid(data, 1, {{1, 2}}));
+  }
+
+  {  // feature mismatch means ID passes
+    hydra::InputData input{nullptr};
+    input.label_features = {{1, getOneHot(4)}};
+    const FrameData data{input};
+    EXPECT_TRUE(filter.valid(data, 1, {{1, 2}}));
+  }
+}
+
+TEST(InstanceForwarding, EmptyInputCorrect) {
+  InstanceForwarding::Config config;
+  InstanceForwarding detector(config);
+
+  hydra::VolumetricMap map(hydra::VolumetricMap::Config{});
+
+  {  // no input means no output
+    hydra::InputData input{nullptr};
+    FrameData data{input};
+    detector.processInput(map, data);
+    EXPECT_TRUE(data.object_image.empty());
+    EXPECT_TRUE(data.semantic_clusters.empty());
+  }
+
+  {  // no instances means no output
+    hydra::InputData input{nullptr};
+    input.instance_image = cv::Mat::zeros(6, 4, CV_16S);
+    input.range_image = cv::Mat(6, 4, CV_32FC1, 1.0f);
+    FrameData data{input};
+    data.object_image = cv::Mat::zeros(6, 4, CV_32S);
+
+    detector.processInput(map, data);
+    EXPECT_TRUE(data.semantic_clusters.empty());
+  }
+}
+
+TEST(InstanceForwarding, ZeroIndexedInstance) {
+  InstanceForwarding::Config config;
+  config.zero_is_unlabeled = false;
+  InstanceForwarding detector(config);
+
+  hydra::VolumetricMap map(hydra::VolumetricMap::Config{});
+
+  hydra::InputData input{nullptr};
+  input.instance_image = cv::Mat::zeros(3, 2, CV_16S);
+  input.range_image = cv::Mat(3, 2, CV_32FC1, 1.0f);
+  FrameData data{input};
+  data.object_image = cv::Mat::zeros(3, 2, CV_32S);
+
+  detector.processInput(map, data);
+  ASSERT_EQ(data.semantic_clusters.size(), 1u);
+  const auto& cluster = data.semantic_clusters[0];
+  Pixels expected{{0, 0}, {0, 1}, {0, 2}, {1, 0}, {1, 1}, {1, 2}};
+  EXPECT_EQ(cluster.pixels, expected);
+  EXPECT_EQ(cluster.semantics, std::nullopt);
+}
+
+TEST(InstanceForwarding, OutOfRange) {
+  InstanceForwarding::Config config;
+  config.zero_is_unlabeled = false;
+  config.min_range = 1.5f;
+  InstanceForwarding detector(config);
+
+  hydra::VolumetricMap map(hydra::VolumetricMap::Config{});
+
+  hydra::InputData input{nullptr};
+  input.instance_image = cv::Mat::zeros(3, 2, CV_16S);
+  input.range_image = cv::Mat(3, 2, CV_32FC1, 1.0f);
+  FrameData data{input};
+  data.object_image = cv::Mat::zeros(3, 2, CV_32S);
+
+  detector.processInput(map, data);
+  EXPECT_EQ(data.semantic_clusters.size(), 0u);
+}
+
+TEST(InstanceForwarding, PartialRange) {
+  InstanceForwarding::Config config;
+  config.zero_is_unlabeled = false;
+  config.min_range = 0.5f;
+  InstanceForwarding detector(config);
+
+  hydra::VolumetricMap map(hydra::VolumetricMap::Config{});
+
+  hydra::InputData input{nullptr};
+  input.instance_image = cv::Mat::zeros(3, 2, CV_16S);
+  input.range_image = cv::Mat(3, 2, CV_32FC1, 1.0f);
+  input.range_image.at<InputData::RangeType>(1, 1) = 0.1f;
+  input.range_image.at<InputData::RangeType>(2, 0) = 0.1f;
+
+  FrameData data{input};
+  data.object_image = cv::Mat::zeros(3, 2, CV_32S);
+
+  detector.processInput(map, data);
+  ASSERT_EQ(data.semantic_clusters.size(), 1u);
+  const auto& cluster = data.semantic_clusters[0];
+  Pixels expected{{0, 0}, {0, 1}, {1, 0}, {1, 2}};
+  EXPECT_EQ(cluster.pixels, expected);
+  EXPECT_EQ(cluster.semantics, std::nullopt);
+}
+
+TEST(InstanceForwarding, ClosedSetLabels) {
+  InstanceForwarding::Config config;
+  config.zero_is_unlabeled = false;
+  config.min_range = 0.5f;
+  InstanceForwarding detector(config);
+
+  hydra::VolumetricMap map(hydra::VolumetricMap::Config{});
+
+  hydra::InputData input{nullptr};
+  input.instance_image = cv::Mat::zeros(3, 2, CV_16S);
+  input.label_image = cv::Mat::zeros(3, 2, CV_32S);
+  input.label_image = 2;
+  input.range_image = cv::Mat(3, 2, CV_32FC1, 1.0f);
+  input.range_image.at<InputData::RangeType>(1, 1) = 0.1f;
+  input.range_image.at<InputData::RangeType>(2, 0) = 0.1f;
+
+  FrameData data{input};
+  data.object_image = cv::Mat::zeros(3, 2, CV_32S);
+
+  detector.processInput(map, data);
+  ASSERT_EQ(data.semantic_clusters.size(), 1u);
+  const auto& cluster = data.semantic_clusters[0];
+  Pixels expected{{0, 0}, {0, 1}, {1, 0}, {1, 2}};
+  EXPECT_EQ(cluster.pixels, expected);
+  const SemanticClusterInfo expected_semantics{2};
+  EXPECT_EQ(cluster.semantics, expected_semantics);
+}
+
+TEST(InstanceForwarding, OpenSetFeatures) {
+  InstanceForwarding::Config config;
+  config.zero_is_unlabeled = false;
+  config.min_range = 0.5f;
+  InstanceForwarding detector(config);
+
+  hydra::VolumetricMap map(hydra::VolumetricMap::Config{});
+
+  hydra::InputData input{nullptr};
+  input.instance_image = cv::Mat::zeros(3, 2, CV_16S);
+  input.instance_image.at<InputData::InstanceType>(0, 0) = 1;
+  input.label_features = {{1, getOneHot(2)}};
+  input.range_image = cv::Mat(3, 2, CV_32FC1, 1.0f);
+  input.range_image.at<InputData::RangeType>(1, 1) = 0.1f;
+  input.range_image.at<InputData::RangeType>(2, 0) = 0.1f;
+
+  FrameData data{input};
+  data.object_image = cv::Mat::zeros(3, 2, CV_32S);
+
+  detector.processInput(map, data);
+  ASSERT_EQ(data.semantic_clusters.size(), 2u);
+
+  {  // first instance has no feature
+    const auto& cluster = data.semantic_clusters[0];
+    Pixels expected{{0, 1}, {1, 0}, {1, 2}};
+    EXPECT_EQ(cluster.pixels, expected);
+    EXPECT_EQ(cluster.semantics, std::nullopt);
+  }
+
+  {
+    const auto& cluster = data.semantic_clusters[1];
+    Pixels expected{{0, 0}};
+    EXPECT_EQ(cluster.pixels, expected);
+    const SemanticClusterInfo expected_semantics{getOneHot(2)};
+    EXPECT_EQ(cluster.semantics, expected_semantics);
+  }
+}
+
+TEST(InstanceForwarding, FilteringCorrect) {
+  ConfigGuard guard;
+
+  InstanceForwarding::Config config;
+  config.zero_is_unlabeled = false;
+  config.min_range = 0.5f;
+  config.min_object_volume = 0.1;
+  config.min_cluster_size = 2;
+
+  CategoryFilter::Config filter_config;
+  filter_config.invalid = {1};
+  config.instance_filter = filter_config;
+  InstanceForwarding detector(config);
+
+  hydra::VolumetricMap map(hydra::VolumetricMap::Config{});
+
+  // four instances: first fails pixels, second volume, third label filter
+  hydra::InputData input{nullptr};
+  input.instance_image = cv::Mat::zeros(4, 2, CV_16S);
+  input.instance_image.at<InputData::InstanceType>(1, 0) = 1;
+  input.instance_image.at<InputData::InstanceType>(1, 1) = 1;
+  input.instance_image.at<InputData::InstanceType>(2, 0) = 2;
+  input.instance_image.at<InputData::InstanceType>(2, 1) = 2;
+  input.instance_image.at<InputData::InstanceType>(3, 0) = 3;
+  input.instance_image.at<InputData::InstanceType>(3, 1) = 3;
+
+  input.label_image = cv::Mat::zeros(4, 2, CV_32S);
+  input.label_image.at<InputData::LabelType>(2, 0) = 1;
+  input.label_image.at<InputData::LabelType>(2, 1) = 1;
+  input.label_image.at<InputData::LabelType>(3, 0) = 2;
+  input.label_image.at<InputData::LabelType>(3, 1) = 2;
+
+  input.range_image = cv::Mat(4, 2, CV_32FC1, 1.0f);
+  input.range_image.at<InputData::RangeType>(0, 1) = 0.1f;
+
+  input.vertex_map = cv::Mat(4, 2, CV_32FC3, cv::Scalar(0.0f, 0.0f, 0.0f));
+  input.vertex_map.at<cv::Vec3f>(2, 1) = cv::Vec3f(1.0f, 1.0f, 1.0f);
+  input.vertex_map.at<cv::Vec3f>(3, 1) = cv::Vec3f(1.0f, 1.0f, 1.0f);
+
+  FrameData data{input};
+  data.object_image = cv::Mat::zeros(4, 2, CV_32S);
+  detector.processInput(map, data);
+
+  ASSERT_EQ(data.semantic_clusters.size(), 1u);
+  const auto& cluster = data.semantic_clusters[0];
+  Pixels expected{{0, 3}, {1, 3}};
+  EXPECT_EQ(cluster.pixels, expected);
+  const SemanticClusterInfo expected_semantics{2};
+  EXPECT_EQ(cluster.semantics, expected_semantics);
+}
 
 }  // namespace khronos

--- a/khronos/tests/main.cpp
+++ b/khronos/tests/main.cpp
@@ -1,0 +1,42 @@
+/* -----------------------------------------------------------------------------
+ * Copyright 2022 Massachusetts Institute of Technology.
+ * All Rights Reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Research was sponsored by the United States Air Force Research Laboratory and
+ * the United States Air Force Artificial Intelligence Accelerator and was
+ * accomplished under Cooperative Agreement Number FA8750-19-2-1000. The views
+ * and conclusions contained in this document are those of the authors and should
+ * not be interpreted as representing the official policies, either expressed or
+ * implied, of the United States Air Force or the U.S. Government. The U.S.
+ * Government is authorized to reproduce and distribute reprints for Government
+ * purposes notwithstanding any copyright notation herein.
+ * -------------------------------------------------------------------------- */
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  google::InitGoogleLogging(argv[0]);
+  return RUN_ALL_TESTS();
+}

--- a/khronos_ros/src/visualization/implicit_shape_plugin.cpp
+++ b/khronos_ros/src/visualization/implicit_shape_plugin.cpp
@@ -23,6 +23,46 @@ static const auto registration = config::RegistrationWithConfig<VisualizerPlugin
 
 inline std::string node_namespace(spark_dsg::NodeSymbol id) { return "crisp_mesh_" + id.str(true); }
 
+void fillRequest(const spark_dsg::KhronosObjectAttributes& attrs,
+                 khronos_msgs::srv::ReconstructImplicitObject::Request& req) {
+  const auto meta = attrs.metadata.get();
+  if (meta.contains("scale")) {
+    req.scale = meta["scale"].get<float>();
+  }
+
+  req.shape_code.insert(req.shape_code.end(),
+                        attrs.semantic_feature.reshaped().begin(),
+                        attrs.semantic_feature.reshaped().end());
+}
+
+void fillMesh(const std_msgs::msg::Header& header,
+              const khronos_msgs::srv::ReconstructImplicitObject::Response& response,
+              const std::string& ns,
+              const spark_dsg::Color& color,
+              kimera_pgmo_msgs::msg::Mesh& msg) {
+  const auto rgb = visualizer::makeColorMsg(color, 1.0);
+  msg.header = header;
+  msg.header.frame_id = ns;
+  msg.ns = ns;
+  msg.vertices.resize(response.vertices.size() / 3);
+  for (size_t i = 0; i + 2 < response.vertices.size(); i += 3) {
+    auto& v = msg.vertices[i / 3];
+    v.pos.x = response.vertices[i];
+    v.pos.y = response.vertices[i + 1];
+    v.pos.z = response.vertices[i + 2];
+    v.has_color = true;
+    v.color = rgb;
+  }
+
+  msg.triangles.resize(response.triangles.size() / 3);
+  for (size_t i = 0; i + 2 < response.triangles.size(); i += 3) {
+    auto& face = msg.triangles[i / 3];
+    face.vertex_indices[0] = response.triangles[i];
+    face.vertex_indices[1] = response.triangles[i + 1];
+    face.vertex_indices[2] = response.triangles[i + 2];
+  }
+}
+
 }  // namespace
 
 using spark_dsg::KhronosObjectAttributes;
@@ -73,7 +113,7 @@ void ImplicitShapePlugin::draw(const std_msgs::msg::Header& header, const SceneG
 
   for (const auto& [node_id, node] : layer.nodes()) {
     const auto attrs = node->tryAttributes<KhronosObjectAttributes>();
-    if (!attrs) {
+    if (!attrs || !attrs->semantic_feature.size()) {
       continue;
     }
 
@@ -101,15 +141,7 @@ void ImplicitShapePlugin::draw(const std_msgs::msg::Header& header, const SceneG
     }
 
     auto req = std::make_shared<ReconstructionSrv::Request>();
-    const auto meta = attrs->metadata.get();
-    if (meta.contains("scale")) {
-      req->scale = meta["scale"].get<float>();
-    }
-
-    req->shape_code.insert(req->shape_code.end(),
-                           attrs->semantic_feature.reshaped().begin(),
-                           attrs->semantic_feature.reshaped().end());
-
+    fillRequest(*attrs, *req);
     const auto rep = ianvs::call_service(*client_, req);
     if (!rep) {
       LOG(ERROR) << "CRISP service call failed!";
@@ -121,32 +153,12 @@ void ImplicitShapePlugin::draw(const std_msgs::msg::Header& header, const SceneG
       color = color_adapter_->getColor(graph, *node);
     }
 
-    VLOG(1) << "Got response of " << rep->vertices.size() << " vertices and "
-            << rep->triangles.size() << " faces";
+    const auto num_verts = rep->vertices.size();
+    const auto num_faces = rep->triangles.size();
+    VLOG(1) << "Got " << num_verts << " vertices and " << num_faces << " faces";
 
-    const auto rgb = visualizer::makeColorMsg(color, 1.0);
     auto msg = std::make_unique<kimera_pgmo_msgs::msg::Mesh>();
-    msg->header = header;
-    msg->header.frame_id = ns;
-    msg->ns = ns;
-    msg->vertices.resize(rep->vertices.size() / 3);
-    for (size_t i = 0; i + 2 < rep->vertices.size(); i += 3) {
-      auto& v = msg->vertices[i / 3];
-      v.pos.x = rep->vertices[i];
-      v.pos.y = rep->vertices[i + 1];
-      v.pos.z = rep->vertices[i + 2];
-      v.has_color = true;
-      v.color = rgb;
-    }
-
-    msg->triangles.resize(rep->triangles.size() / 3);
-    for (size_t i = 0; i + 2 < rep->triangles.size(); i += 3) {
-      auto& face = msg->triangles[i / 3];
-      face.vertex_indices[0] = rep->triangles[i];
-      face.vertex_indices[1] = rep->triangles[i + 1];
-      face.vertex_indices[2] = rep->triangles[i + 2];
-    }
-
+    fillMesh(header, *rep, ns, color, *msg);
     pub_->publish(std::move(msg));
   }
 


### PR DESCRIPTION
Changes:
- Adds unit tests for Khronos (specifically for the `InstanceForwarding` object detector)
- Cleans up filtering of forwarded instances by semantic info (by adding optional filter classes)
- Fix default semantic feature to be empty instead of being a single element
- Update `InstanceForwarding` to use `instance_image` field in input instead of `label_image` and fix conversion bug
- Updates mesh publishing for implicit shape plugin
- Fix some code style